### PR TITLE
Optrobo

### DIFF
--- a/lib/Win32/Backup/Robocopy.pm
+++ b/lib/Win32/Backup/Robocopy.pm
@@ -302,7 +302,7 @@ sub restore{
 	my @extra =  ref $arg{extraparam} eq 'ARRAY' 	?
 					@{ $arg{extraparam} }			:
 					split /\s+/, $arg{extraparam} // ''	;
-	my @robo_params = ( '*.*', '/S', '/E', '/DCOPY:T', '/SEC', '/R:0', '/W:0', @extra );
+	my @robo_params = ( '*.*', '/S', '/E', '/R:0', '/W:0', @extra ); #'/DCOPY:T', '/SEC',
 	# build parameters to ROBOCOPY using some default and extraparam
 	# check if it is a restore from a history backup
 	opendir my $dirh, $arg{from} or croak "unable to open dir [$arg{from}] to read";

--- a/lib/Win32/Backup/Robocopy.pm
+++ b/lib/Win32/Backup/Robocopy.pm
@@ -29,7 +29,7 @@ sub new {
 				conf 		=> $arg{conf} ,
 				jobs 		=> $jobs // [],
 				verbose 	=> $arg{verbose},
-				debug		=> $arg {debug},
+				#debug		=> $arg {debug},
 				#writelog	=> $arg {writelog},
 			}, $class;	
 	}
@@ -42,7 +42,7 @@ sub new {
 				dst 		=> $arg{dst},
 				history 	=> $arg{history} // 0,
 				verbose 	=> $arg{verbose} // 0,
-				debug		=> $arg{debug} // 0,
+				#debug		=> $arg{debug} // 0,
 				waitdrive	=> $arg{waitdrive} // 0,
 				#writelog	=> $arg {writelog} // 1,
 	}, $class;
@@ -186,7 +186,7 @@ sub job {
 	}
 	# clean the main object of other (now unwanted) properties
 	$self->_write_conf;
-	map{ delete $self->{$_} }qw( name src dst history debug verbose );
+	map{ delete $self->{$_} }qw( name src dst history verbose );
 }
 
 sub runjobs{
@@ -217,7 +217,7 @@ sub runjobs{
 				dst 		=> $job->{dst},
 				history 	=> $job->{history} // 0,
 				verbose 	=> $job->{verbose} // 0,
-				debug		=> $job->{debug} // 0,
+				#debug		=> $job->{debug} // 0,
 				waitdrive	=> $job->{waitdrive} // 0,
 				#writelog	=> $job->{writelog} // 1,
 			},ref $self;
@@ -250,7 +250,7 @@ sub listjobs{
 	$arg{format} //= 'compact';
 	$arg{fields} //= [qw( name src dst files history cron next_time next_time_descr
 							first_time_run archive archiveremove subfolders emptysubfolders
-							 waitdrive verbose debug)];
+							 waitdrive verbose )];
 							
 	unless ( wantarray ){ return scalar @{$self->{jobs}} }
 	my @res;
@@ -526,7 +526,7 @@ sub _load_conf{
 	croak "not an ARRAY ref retrieved from $file as conteainer for jobs! wrong configuration" 
 			unless ref $data eq 'ARRAY';
 	my @check = qw( name src dst files history cron next_time next_time_descr first_time_run archive
-				archiveremove subfolders emptysubfolders verbose debug waitdrive wait retries);
+				archiveremove subfolders emptysubfolders verbose waitdrive wait retries);
 	my $count = 1;
 	foreach my $job ( @$data ){
 		croak "not a HASH ref retrieved from $file for job $count! wrong configuration" 
@@ -599,9 +599,12 @@ sub _ordered_json{
 			subfolders=> 10,	 # run
 			emptysubfolders=> 11,# run
 			
-			waitdrive => 12,	# new
-			verbose	=> 13, 		# new
-			debug	=>	15, 	# new
+			retries  => 12,
+			wait => 13,
+			
+			waitdrive => 14,	# new
+			verbose	=> 15, 		# new
+			#debug	=>	15, 	# new
 	);
 	($order{$JSON::PP::a} // 99) <=> ($order{$JSON::PP::b} // 99)
 }
@@ -609,7 +612,7 @@ sub _default_new_params{
 	my %opt = @_;
 	$opt{history} //= 0;
 	$opt{verbose} //= 0;
-	$opt{debug} //= 0;
+	#$opt{debug} //= 0;
 	$opt{waitdrive} //= 0;
 	return %opt;
 }
@@ -1166,10 +1169,10 @@ Will produce the following configuration:
       "archiveremove" : 1,
       "subfolders" : 1,
       "emptysubfolders" : 1,
-      "noprogress" : 1,
+      "retries" : 0,
+      "wait" : 0,
       "waitdrive" : 0,
-      "verbose" : 0,
-      "debug" : 0
+      "verbose" : 0
      }
   ]
 

--- a/lib/Win32/Backup/Robocopy.pm
+++ b/lib/Win32/Backup/Robocopy.pm
@@ -826,7 +826,7 @@ By other hand, if nothing is specified, every call of the C<restore> method will
 
     robocopy.exe SOURCE DESTINATION *.* /S /E /R:0 /W:0 /NP /256 
 	
-with the important difference respect to archive bit that are not looked for nor reset.
+with the only but important difference in respect to archive bit that are not looked for nor reset ( no C</M> switch passed ).
 
 =head2 about verbosity
 

--- a/lib/Win32/Backup/Robocopy.pm
+++ b/lib/Win32/Backup/Robocopy.pm
@@ -824,7 +824,7 @@ Even specialized tools can fail ( booting Linux live distro and good old C<rm -r
 
 By other hand, if nothing is specified, every call of the C<restore> method will result in:
 
-    robocopy.exe SOURCE DESTINATION *.* /S /E /DCOPY:T /SEC /R:0 /W:0 /NP /256 
+    robocopy.exe SOURCE DESTINATION *.* /S /E /R:0 /W:0 /NP /256 
 	
 with the important difference respect to archive bit that are not looked for nor reset.
 
@@ -1130,7 +1130,7 @@ Pay attention to what is said in the L<DateTime::Tiny> documentation about time 
     gmtime:    Sun Jan  6 20:29:10 2019
 
 
-The C<restore> method will execute a C<robocopy.exe> call with defaut arguments C<'*.*', '/S', '/E', '/DCOPY:T', '/SEC', '/NP' '/256'> but you can pass other ones using the C<extraparam> parameter being it a string or an array reference with a list of valid C<robocopy.exe> parameters.
+The C<restore> method will execute a C<robocopy.exe> call with defaut arguments C<'*.*', '/S', '/E', '/NP' '/256'> but you can pass other ones using the C<extraparam> parameter being it a string or an array reference with a list of valid C<robocopy.exe> parameters.
 
 Both history and normal restore can output more informations if C<verbose> is set in the main backup object or if it is passed in directly during the C<restore> method call.
 

--- a/lib/Win32/Backup/Robocopy.pm
+++ b/lib/Win32/Backup/Robocopy.pm
@@ -250,6 +250,7 @@ sub listjobs{
 	$arg{format} //= 'compact';
 	$arg{fields} //= [qw( name src dst files history cron next_time next_time_descr
 							first_time_run archive archiveremove subfolders emptysubfolders
+							retries wait
 							 waitdrive verbose )];
 							
 	unless ( wantarray ){ return scalar @{$self->{jobs}} }
@@ -599,8 +600,8 @@ sub _ordered_json{
 			subfolders=> 10,	 # run
 			emptysubfolders=> 11,# run
 			
-			retries  => 12,
-			wait => 13,
+			retries  => 12,      # run
+			wait => 13,          # run
 			
 			waitdrive => 14,	# new
 			verbose	=> 15, 		# new

--- a/t/03-job.t
+++ b/t/03-job.t
@@ -25,8 +25,8 @@ ok ( defined $bkp->{conf}, 'config as alias for conf');
 $bkp = Win32::Backup::Robocopy->new( configuration => File::Spec->catfile($tbasedir,'my_config.json') );
 ok ( defined $bkp->{conf}, 'configuration as alias for conf');
 
-# $bkp has only 4 fields
-ok(keys %$bkp == 4, 'just 4 fields in bkp object');
+# $bkp has only 3 fields
+ok(keys %$bkp == 3, 'just 3 fields in bkp object');
 
 # job dies if nothing is given
 dies_ok { $bkp->job } 'job method expected to die without a name, a source and a cron string';
@@ -53,7 +53,7 @@ ok(@{$bkp->{jobs}} == 1, 'first job correctly pushed into jobs queue');
 # job has taken all defaults from new and run
 foreach my $field (qw( 	name src dst files history archive 
 						archiveremove subfolders emptysubfolders 
-						debug verbose )) {
+						verbose )) {
 	ok(defined ${$bkp->{jobs}}[0]->{$field}, "$field defined in job" );
 }
 


### PR DESCRIPTION
just fixed defaults of restore similare to those used in run. Documented too.
Abandoned the idea of an alternative path for robocopy