### PR TITLE
Optrestore

### DIFF
--- a/lib/Win32/Backup/Robocopy.pm
+++ b/lib/Win32/Backup/Robocopy.pm
@@ -1178,6 +1178,46 @@ The return value of a C<restore> call will be an anonymous array with an element
 if it was a history restore each operation (using a different folder as source) will push an 
 element in the array. These array elements are anonymoous hashes with four keys:  C<stdout>, C<stderr>, C<exit> and C<exitstring> of each operation respectively.
 
+=head2 optional parameter
+
+The C<restore> method will accept all parameter concerning C<robocopy> options as the C<run> method do, with only important difference about archive bit: the default is to ignore it.
+
+=over 
+
+=item 
+
+C<files> defaults to C<*.*>  robocopy will assume all file unless specified: the module passes it explicitly (see below)
+
+=item 
+
+C<archive> defaults to 0 and will set the C</A> if 1 ( copy only files with the archive attribute set ) robocopy switch
+
+=item 
+
+C<archiveremove> defaults to 0 (the only difference in respect of the run method) and will set the C</M> ( like C</A>, but remove archive attribute from source files ) robocopy switch
+
+=item 
+
+C<subfolders> defaults to 1 and will set the C</S> if 1 ( copy subfolders ) robocopy switch
+
+=item 
+
+C<emptysubfolders> defaults to 1 and will set the C</E> ( copy subfolders, including empty subfolders ) robocopy switch
+
+=item 
+
+C<retries> defaults to 0 and will set the C</R:0> or N if specified (number of retries on error on file) robocopy switch
+
+=item 
+
+C<wait> defaults to 0 and will set the C</W:0> or N if specified (seconds between retries) robocopy switch
+
+=item 
+
+C<extraparam> defaults to undef and can be used to pass any valid option to robocopy (see below)
+
+=back
+
 
 =head1 CONFIGURATION FILE
 

--- a/lib/Win32/Backup/Robocopy.pm
+++ b/lib/Win32/Backup/Robocopy.pm
@@ -1046,6 +1046,14 @@ If, by other hand, the file does not exists,  C<new> does not complain, assuming
 
 =head2 job
 
+    $bkp->job( 
+        name => 'documents',
+        src  => 'e:\me\docs',
+        dst  => 'x:\my_backups'		
+        cron => '0 0 25 12 *',
+    );
+
+
 This method will push job in the queue. It accepts all parameters of the C<new> and the C<run> methods described in RUN mode above.
 Infact a job, when run, will instantiate a new backup object and will run it via the C<run> method.
 

--- a/lib/Win32/Backup/Robocopy.pm
+++ b/lib/Win32/Backup/Robocopy.pm
@@ -864,6 +864,8 @@ By other hand, if nothing is specified, every call of the C<restore> method will
 	
 with the only but important difference in respect to archive bit that are not looked for nor reset ( no C</M> switch passed ).
 
+Please not that C<robocopy.exe> will use by default C</COPY:DAT> ie will copy data, attributes and timestamp.
+
 =head2 about verbosity
 
 Verbosity of the module can vary from C<0> (default value, no outptut at all) to C<2> giving lot of informations and dumping jobs and configuration. 

--- a/lib/Win32/Backup/Robocopy.pm
+++ b/lib/Win32/Backup/Robocopy.pm
@@ -1194,7 +1194,7 @@ C<archive> defaults to 0 and will set the C</A> if 1 ( copy only files with the 
 
 =item 
 
-C<archiveremove> defaults to 0 (the only difference in respect of the run method) and will set the C</M> ( like C</A>, but remove archive attribute from source files ) robocopy switch
+C<archiveremove> defaults to 0 (the only difference in respect of the run method) and will set the C</M> ( like C</A>, but remove archive attribute ) robocopy switch
 
 =item 
 

--- a/lib/Win32/Backup/Robocopy.pm
+++ b/lib/Win32/Backup/Robocopy.pm
@@ -1180,7 +1180,7 @@ element in the array. These array elements are anonymoous hashes with four keys:
 
 =head2 optional parameter
 
-The C<restore> method will accept all parameter concerning C<robocopy> options as the C<run> method do, with only important difference about archive bit: the default is to ignore it.
+The C<restore> method will accept all parameter concerning C<robocopy> options as the C<run> method do, with the only important difference about archive bit: the default is to ignore it.
 
 =over 
 

--- a/lib/Win32/Backup/Robocopy.pm
+++ b/lib/Win32/Backup/Robocopy.pm
@@ -1214,7 +1214,7 @@ C<wait> defaults to 0 and will set the C</W:0> or N if specified (seconds betwee
 
 =item 
 
-C<extraparam> defaults to undef and can be used to pass any valid option to robocopy (see below)
+C<extraparam> defaults to undef and can be used to pass any valid option to robocopy (see run method)
 
 =back
 


### PR DESCRIPTION
used _default_restore_params to have the same parmeters used in run usable in restore.
corrected POD 